### PR TITLE
Remove dockerhub login step, use ECR public gallery ubuntu image, and update eksctl latest git release URL

### DIFF
--- a/test/canary/Dockerfile.canary
+++ b/test/canary/Dockerfile.canary
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04
 
 # Build time parameters 
 ARG SERVICE=applicationautoscaling

--- a/test/canary/Dockerfile.canary
+++ b/test/canary/Dockerfile.canary
@@ -30,7 +30,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.6/b
  && cp ./kubectl /bin
 
 # Install eksctl
-RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && mv /tmp/eksctl /bin
+RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && mv /tmp/eksctl /bin
 
 # Install Helm 
 RUN curl -q -L "https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz" | tar zxf - -C /usr/local/bin/ \

--- a/test/canary/canary.buildspec.yaml
+++ b/test/canary/canary.buildspec.yaml
@@ -10,9 +10,6 @@ phases:
       - aws ecr get-login-password --region $CLUSTER_REGION | docker login --username AWS --password-stdin $ECR_CACHE_URI || true
       - docker pull ${ECR_CACHE_URI}:latest --quiet || true
 
-      # Login to dockerhub to avoid hitting throttle limit
-      - docker login -u $DOCKER_CONFIG_USERNAME -p $DOCKER_CONFIG_PASSWORD
-
       # Build test image
       - >
         docker build -f ./test/canary/Dockerfile.canary . -t ${ECR_CACHE_URI}:latest


### PR DESCRIPTION
Changelist:
- Remove dockerhub login step
- Use ECR public gallery ubuntu image
- Fixed issue where eksctl latest git release URL was not up to date and could not be found

Precedence for changes:
- Remove dockerhub login step and use ECR public gallery ubuntu image: https://github.com/aws-controllers-k8s/sagemaker-controller/pull/78/commits/2ae5c33433a01c46e743db3e6908c4b19a567328
- Update eksctl latest git release URL: https://github.com/aws-controllers-k8s/sagemaker-controller/pull/87